### PR TITLE
Hotfix invalidation for file paths

### DIFF
--- a/classes/wp-amazon-c3-cloudfront-clear-cache.php
+++ b/classes/wp-amazon-c3-cloudfront-clear-cache.php
@@ -490,9 +490,9 @@ class C3_CloudFront_Clear_Cache extends AWS_Plugin_Base {
 
     function stringToArray($path) {
 
-        $tail = '';
-        if(substr($path , -1)=='/'){
-            $tail = '/';
+        $tail = '/';
+        if(pathinfo($path, PATHINFO_EXTENSION)) {
+            $tail = '';
         }
         $separator = '/';
         $path      = trim($path, '/');

--- a/classes/wp-amazon-c3-cloudfront-clear-cache.php
+++ b/classes/wp-amazon-c3-cloudfront-clear-cache.php
@@ -489,6 +489,11 @@ class C3_CloudFront_Clear_Cache extends AWS_Plugin_Base {
     }
 
     function stringToArray($path) {
+
+        $tail = '';
+        if(substr($path , -1)=='/'){
+            $tail = '/';
+        }
         $separator = '/';
         $path      = trim($path, '/');
         $pos       = strpos($path, $separator);
@@ -501,7 +506,7 @@ class C3_CloudFront_Clear_Cache extends AWS_Plugin_Base {
                 return ['/'];
             }
 
-            return ['/' . $path . '/'];
+            return ['/' . $path . $tail];
         }
 
         $key  = substr($path, 0, $pos);


### PR DESCRIPTION
Path '/app/uploads/2020/10/file-name.pdf' will be fixed to '/app/uploads/2020/10/file-name.pdf/' in stringToArray. Hotfix if the path does not end in / do no presume so. Maybe could be completely rewritten but not sure what is the true purpose of this recursive parsing.